### PR TITLE
Minor fix in local runtime.

### DIFF
--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -321,7 +321,7 @@ class LocalRuntime(runtime.Runtime):
     @tenacity.retry(stop=tenacity.stop_after_attempt(20),
                     wait=tenacity.wait_exponential(multiplier=1, max=12),
                     # return last value and don't raise RetryError exception.
-                    retry_error_callback=lambda lv: lv.result(),
+                    retry_error_callback=lambda lv: lv.outcome.result(),
                     retry=tenacity.retry_if_result(lambda v: v is False))
     def _is_service_healthy(self, service: docker_models_services.Service, replicas=None) -> bool:
         """Checks if a docker service is healthy by checking all tasks status."""


### PR DESCRIPTION
lv.result() : AttributeError: 'RetryCallState' object has no attribute 'result'
