### PR TITLE
Cleanup of the configuration manager to be more pythonic and fix missing API key

### DIFF
--- a/src/ostorlab/apis/runners/authenticated_runner.py
+++ b/src/ostorlab/apis/runners/authenticated_runner.py
@@ -56,7 +56,7 @@ class AuthenticatedAPIRunner(runner.APIRunner):
         self._username = username
         self._password = password
         self._token_duration = token_duration
-        self._api_key = api_key or self._configuration_manager.get_api_key()
+        self._api_key = api_key or self._configuration_manager.api_key
         self._token: Optional[str] = None
         self._otp_token: Optional[str] = None
 

--- a/src/ostorlab/cli/auth/revoke/revoke.py
+++ b/src/ostorlab/cli/auth/revoke/revoke.py
@@ -20,7 +20,7 @@ def revoke():
     config_manager = configuration_manager.ConfigurationManager()
 
     try:
-        api_key_id = config_manager.get_api_key_id()
+        api_key_id = config_manager.api_key_id
         api_runner = authenticated_runner.AuthenticatedAPIRunner()
 
         with console.status('Revoking API key'):

--- a/src/ostorlab/cli/rootcli.py
+++ b/src/ostorlab/cli/rootcli.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 import click
 
+from ostorlab import configuration_manager
+
 logger = logging.getLogger('CLI')
 
 
@@ -22,6 +24,11 @@ def rootcli(ctx: click.core.Context, proxy: Optional[str] = None, tlsverify: Opt
     ctx.obj['proxy'] = proxy
     ctx.obj['tlsverify'] = tlsverify
     ctx.obj['api_key'] = api_key
+    # Configuration is a singleton class. One initiated with the provided API key, others will make use of it.
+    conf_manager = configuration_manager.ConfigurationManager()
+    conf_manager.api_key = api_key
+    ctx.obj['config_manager'] = conf_manager
+
     if verbose is True:
         loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
         for l in loggers:

--- a/tests/cli/agent/search/search_test.py
+++ b/tests/cli/agent/search/search_test.py
@@ -7,11 +7,11 @@ from ostorlab.cli import rootcli
 
 
 def testAgentSearchCLI_WhenAuthenticatedRunner_listAgents(mocker, requests_mock):
-    """Test ostorlab agent search CLI command with Autenticated API returns list of agents.
-    """
+    """Test ostorlab agent search CLI command with Autenticated API returns list of agents."""
     mock.patch('ostorlab.api.runners.authenticated_runner')
-    mocker.patch('ostorlab.configuration_manager.ConfigurationManager.get_api_key_id', return_value='test')
-    mocker.patch('ostorlab.configuration_manager.ConfigurationManager.get_api_key', return_value='test')
+    mocker.patch('ostorlab.configuration_manager.ConfigurationManager.api_key',
+                 new_callable=mock.PropertyMock,
+                 return_value='test')
     agents_dict = {
         'data': {
             'agents': {
@@ -50,9 +50,7 @@ def testAgentSearchCLI_WhenAuthenticatedRunner_listAgents(mocker, requests_mock)
 
 
 def testAgentSearchCLI_WhenPublicRunner_listAgents(mocker, requests_mock):
-    """Test ostorlab agent search CLI command with Public API returns list of agents.
-    """
-    mocker.patch('ostorlab.configuration_manager.ConfigurationManager.get_api_key_id', return_value=None)
+    """Test ostorlab agent search CLI command with Public API returns list of agents."""
     agents_dict = {
         'data': {
             'agents': {

--- a/tests/cli/auth/test_login.py
+++ b/tests/cli/auth/test_login.py
@@ -58,7 +58,7 @@ def testOstorlabAuthLoginCLI_whenValidLoginCredentialsAreProvided_tokenSet(
 
     assert result.exception is None
     assert configuration_manager.ConfigurationManager(
-    ).get_api_key() == api_key_dict['data']['createApiKey']['apiKey']['secretKey']
+    ).api_key == api_key_dict['data']['createApiKey']['apiKey']['secretKey']
 
 
 @mock.patch.object(click, 'prompt')

--- a/tests/cli/auth/test_revoke.py
+++ b/tests/cli/auth/test_revoke.py
@@ -22,7 +22,7 @@ def testOstorlabAuthRevokeCLI_whenValidApiKeyIdIsProvided_apiDataDeleted(request
 
     assert result.exception is None
     assert configuration_manager.ConfigurationManager(
-    ).get_api_data() is None
+    ).api_key is None
 
 
 @mock.patch.object(authenticated_runner.AuthenticatedAPIRunner, 'unauthenticate')


### PR DESCRIPTION
Remove dead code.
Add singleton pattern to the configuration manger to set once and use everywhere.