### PR TITLE
Change the order of actions to

### DIFF
--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -182,17 +182,18 @@ class LocalRuntime(runtime.Runtime):
             if is_healthy is False:
                 raise AgentNotHealthy()
 
+            self._inject_assets(assets)
+            console.info('Updating scan status')
+            self._update_scan_progress('IN_PROGRESS')
+
             console.info('Starting post-agents')
             self._start_post_agents()
             console.info('Checking post-agents are healthy')
             is_healthy = self._check_agents_healthy()
             if is_healthy is False:
                 raise AgentNotHealthy()
-            self._inject_assets(assets)
-            console.info('Updating scan status')
-            self._update_scan_progress('IN_PROGRESS')
-            console.success('Scan created successfully')
 
+            console.success('Scan created successfully')
         except AgentNotHealthy:
             console.error('Agent not starting')
             self.stop(self._scan_db.id)


### PR DESCRIPTION
 Due to injecting assets taking too long to run, this PR changes the order of actions to have assets injected before the tracker starts.

This way if injections, take too long, the tracker will always see messages.