### PR TITLE
Fix retry causing an exception.

### DIFF
--- a/src/ostorlab/runtimes/lite_local/runtime.py
+++ b/src/ostorlab/runtimes/lite_local/runtime.py
@@ -248,7 +248,7 @@ class LiteLocalRuntime(runtime.Runtime):
     @tenacity.retry(stop=tenacity.stop_after_attempt(20),
                     wait=tenacity.wait_exponential(multiplier=1, max=12),
                     # return last value and don't raise RetryError exception.
-                    retry_error_callback=lambda lv: lv.outcome.result(),
+                    retry_error_callback=lambda lv: lv.result(),
                     retry=tenacity.retry_if_result(lambda v: v is False))
     def _is_service_healthy(self, service: docker_models_services.Service, replicas=None) -> bool:
         """Checks if a docker service is healthy by checking all tasks status."""
@@ -296,7 +296,7 @@ class LiteLocalRuntime(runtime.Runtime):
     @tenacity.retry(stop=tenacity.stop_after_attempt(20),
                     wait=tenacity.wait_exponential(multiplier=1, max=20),
                     # return last value and don't raise RetryError exception.
-                    retry_error_callback=lambda lv: lv.outcome.result(),
+                    retry_error_callback=lambda lv: lv.result(),
                     retry=tenacity.retry_if_result(lambda v: v is False))
     def list(self, **kwargs):
         raise NotImplementedError()

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -370,7 +370,7 @@ class LocalRuntime(runtime.Runtime):
     @tenacity.retry(stop=tenacity.stop_after_attempt(20),
                     wait=tenacity.wait_exponential(multiplier=1, max=12),
                     # return last value and don't raise RetryError exception.
-                    retry_error_callback=lambda lv: lv.outcome.result(),
+                    retry_error_callback=lambda lv: lv.result(),
                     retry=tenacity.retry_if_result(lambda v: v is False))
     def _is_service_healthy(self, service: docker_models_services.Service, replicas=None) -> bool:
         """Checks if a docker service is healthy by checking all tasks status."""
@@ -471,7 +471,7 @@ class LocalRuntime(runtime.Runtime):
     @tenacity.retry(stop=tenacity.stop_after_attempt(20),
                     wait=tenacity.wait_exponential(multiplier=1, max=20),
                     # return last value and don't raise RetryError exception.
-                    retry_error_callback=lambda lv: lv.outcome.result(),
+                    retry_error_callback=lambda lv: lv.result(),
                     retry=tenacity.retry_if_result(lambda v: v is False))
     def _are_agents_ready(self, fail_fast=True) -> bool:
         """Checks that all agents are ready and healthy while taking into account the run type of agent

--- a/src/ostorlab/runtimes/local/services/mq.py
+++ b/src/ostorlab/runtimes/local/services/mq.py
@@ -114,7 +114,7 @@ class LocalRabbitMQ:
     @tenacity.retry(stop=tenacity.stop_after_attempt(20),
                     wait=tenacity.wait_exponential(multiplier=1, max=12),
                     # return last value and don't raise RetryError exception.
-                    retry_error_callback=lambda lv: lv.outcome.result(),
+                    retry_error_callback=lambda lv: lv.result(),
                     retry=tenacity.retry_if_result(lambda v: v is False))
     def _is_service_healthy(self) -> bool:
         logger.info('checking service %s', self._mq_service.name)

--- a/src/ostorlab/runtimes/local/services/redis.py
+++ b/src/ostorlab/runtimes/local/services/redis.py
@@ -98,7 +98,7 @@ class LocalRedis:
     @tenacity.retry(stop=tenacity.stop_after_attempt(20),
                     wait=tenacity.wait_exponential(multiplier=1, max=12),
                     # return last value and don't raise RetryError exception.
-                    retry_error_callback=lambda lv: lv.outcome.result(),
+                    retry_error_callback=lambda lv: lv.result(),
                     retry=tenacity.retry_if_result(lambda v: v is False))
     def _is_service_healthy(self) -> bool:
         logger.info('checking service %s', self._redis_service.name)


### PR DESCRIPTION
The retry function is causing an exception due to incorrect value access:

```
Traceback (most recent call last):
  File "/home/asm/.local/bin/ostorlab", line 8, in <module>
    sys.exit(main())
  File "/home/asm/.local/lib/python3.8/site-packages/ostorlab/__init__.py", line 15, in main
    rootcli(None)
  File "/home/asm/.local/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/asm/.local/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/asm/.local/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/asm/.local/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/asm/.local/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/asm/.local/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/asm/.local/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/asm/.local/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/asm/.local/lib/python3.8/site-packages/ostorlab/cli/scan/run/assets/ip.py", line 37, in ip_cli
    runtime.scan(title=ctx.obj['title'], agent_group_definition=ctx.obj['agent_group_definition'], assets=assets)
  File "/home/asm/.local/lib/python3.8/site-packages/ostorlab/runtimes/local/runtime.py", line 177, in scan
    is_healthy = self._check_agents_healthy()
  File "/home/asm/.local/lib/python3.8/site-packages/ostorlab/runtimes/local/runtime.py", line 326, in _check_agents_healthy
    return self._are_agents_ready()
  File "/home/asm/.local/lib/python3.8/site-packages/tenacity/__init__.py", line 329, in wrapped_f
    return self.call(f, *args, **kw)
  File "/home/asm/.local/lib/python3.8/site-packages/tenacity/__init__.py", line 409, in call
    do = self.iter(retry_state=retry_state)
  File "/home/asm/.local/lib/python3.8/site-packages/tenacity/__init__.py", line 356, in iter
    return fut.result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/home/asm/.local/lib/python3.8/site-packages/tenacity/__init__.py", line 412, in call
    result = fn(*args, **kwargs)
  File "/home/asm/.local/lib/python3.8/site-packages/ostorlab/runtimes/local/runtime.py", line 484, in _are_agents_ready
    if self._is_service_healthy(service):
  File "/home/asm/.local/lib/python3.8/site-packages/tenacity/__init__.py", line 329, in wrapped_f
    return self.call(f, *args, **kw)
  File "/home/asm/.local/lib/python3.8/site-packages/tenacity/__init__.py", line 409, in call
    do = self.iter(retry_state=retry_state)
  File "/home/asm/.local/lib/python3.8/site-packages/tenacity/__init__.py", line 365, in iter
    return self.retry_error_callback(retry_state=retry_state)
  File "/home/asm/.local/lib/python3.8/site-packages/tenacity/compat.py", line 300, in wrapped_retry_error_callback
    return fn(retry_state.outcome)
  File "/home/asm/.local/lib/python3.8/site-packages/ostorlab/runtimes/local/runtime.py", line 373, in <lambda>
    retry_error_callback=lambda lv: lv.outcome.result(),
AttributeError: 'Future' object has no attribute 'outcome'
```