### PR TITLE
Implement arch check

### DIFF
--- a/src/ostorlab/cli/agent/install/install.py
+++ b/src/ostorlab/cli/agent/install/install.py
@@ -21,7 +21,6 @@ def install(agent: str, version: str = '') -> None:
         console.error('Docker is not installed.')
         raise click.exceptions.Exit(2)
     elif not docker_requirements_checker.is_sys_arch_supported():
-        console.info("install call")
         console.error('System architecture is not supported.')
         raise click.exceptions.Exit(2)
     elif not docker_requirements_checker.is_user_permitted():

--- a/src/ostorlab/cli/agent/install/install.py
+++ b/src/ostorlab/cli/agent/install/install.py
@@ -20,6 +20,10 @@ def install(agent: str, version: str = '') -> None:
     if not docker_requirements_checker.is_docker_installed():
         console.error('Docker is not installed.')
         raise click.exceptions.Exit(2)
+    elif not docker_requirements_checker.is_sys_arch_supported():
+        console.info("install call")
+        console.error('System architecture is not supported.')
+        raise click.exceptions.Exit(2)
     elif not docker_requirements_checker.is_user_permitted():
         console.error('User does not have permissions to run docker.')
         raise click.exceptions.Exit(2)

--- a/src/ostorlab/cli/docker_requirements_checker.py
+++ b/src/ostorlab/cli/docker_requirements_checker.py
@@ -1,6 +1,7 @@
 """Check if requirements for running docker are satisfied."""
 
 import docker
+import platform
 import sys
 from docker import errors
 
@@ -18,6 +19,24 @@ def is_docker_installed() -> bool:
             return False
     return True
 
+def is_sys_arch_supported() -> bool:
+    """Checks if the systems cpu architecture is supported
+       The architecture is checked with a return value that's based on the kernel implementation of the uname(2)
+       system call. So it might be necesarry to handle the same arch with various strings e.g. linux returns x86_64
+       or AMD64 on windows.
+    Returns:
+        True if the architecture is supported, else False
+    """
+    supported_arch_types = ["x86_64", "AMD64"]
+    if sys.platform == 'darwin' and 'ARM' in platform.version():
+        """On mac os, uname returns x86 even on arm64 if the process calling it is running via rosetta. We parse for ARM
+           in platform.version() to determine the arch on mac os
+        """
+        return False
+    else: 
+        if platform.machine() not in supported_arch_types:
+            return False
+    return True
 
 def is_user_permitted() -> bool:
     """Check if the user got permissions to run docker.

--- a/src/ostorlab/cli/docker_requirements_checker.py
+++ b/src/ostorlab/cli/docker_requirements_checker.py
@@ -5,7 +5,7 @@ import platform
 import sys
 from docker import errors
 
-_SUPPORTED_ARCH_TYPES = ["x86_64", "AMD64"]
+_SUPPORTED_ARCH_TYPES = ['x86_64', 'AMD64']
 # The architecture is checked with a return value that's based on the kernel implementation of the uname(2)
 # system call. So it might be necesarry to handle the same arch with various strings e.g. linux returns x86_64
 # or AMD64 on windows.
@@ -33,7 +33,7 @@ def is_sys_arch_supported() -> bool:
         # On mac os, uname returns x86 even on arm64 if the process calling it is running via rosetta. We parse for ARM
         # in platform.version() to determine the arch on mac os
         return False
-    else: 
+    else:
         if platform.machine() not in _SUPPORTED_ARCH_TYPES:
             return False
     return True

--- a/src/ostorlab/cli/docker_requirements_checker.py
+++ b/src/ostorlab/cli/docker_requirements_checker.py
@@ -5,6 +5,10 @@ import platform
 import sys
 from docker import errors
 
+_SUPPORTED_ARCH_TYPES = ["x86_64", "AMD64"]
+# The architecture is checked with a return value that's based on the kernel implementation of the uname(2)
+# system call. So it might be necesarry to handle the same arch with various strings e.g. linux returns x86_64
+# or AMD64 on windows.
 
 def is_docker_installed() -> bool:
     """Checks if docker is installed
@@ -21,20 +25,16 @@ def is_docker_installed() -> bool:
 
 def is_sys_arch_supported() -> bool:
     """Checks if the systems cpu architecture is supported
-       The architecture is checked with a return value that's based on the kernel implementation of the uname(2)
-       system call. So it might be necesarry to handle the same arch with various strings e.g. linux returns x86_64
-       or AMD64 on windows.
+
     Returns:
         True if the architecture is supported, else False
     """
-    supported_arch_types = ["x86_64", "AMD64"]
     if sys.platform == 'darwin' and 'ARM' in platform.version():
-        """On mac os, uname returns x86 even on arm64 if the process calling it is running via rosetta. We parse for ARM
-           in platform.version() to determine the arch on mac os
-        """
+        # On mac os, uname returns x86 even on arm64 if the process calling it is running via rosetta. We parse for ARM
+        # in platform.version() to determine the arch on mac os
         return False
     else: 
-        if platform.machine() not in supported_arch_types:
+        if platform.machine() not in _SUPPORTED_ARCH_TYPES:
             return False
     return True
 

--- a/src/ostorlab/runtimes/lite_local/runtime.py
+++ b/src/ostorlab/runtimes/lite_local/runtime.py
@@ -92,6 +92,9 @@ class LiteLocalRuntime(runtime.Runtime):
         if not docker_requirements_checker.is_docker_installed():
             console.error('Docker is not installed.')
             raise click.exceptions.Exit(2)
+        elif not docker_requirements_checker.is_sys_arch_supported():
+            console.error('System architecture is not supported.')
+            raise click.exceptions.Exit(2)
         elif not docker_requirements_checker.is_user_permitted():
             console.error('User does not have permissions to run docker.')
             raise click.exceptions.Exit(2)

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -125,9 +125,12 @@ class LocalRuntime(runtime.Runtime):
         return True
 
     def _docker_checks(self):
-        """checking the requirements (docker, swarm,permissions) for ostorlab."""
+        """checking the requirements (docker,swarm,arch,permissions) for ostorlab."""
         if not docker_requirements_checker.is_docker_installed():
             console.error('Docker is not installed.')
+            raise click.exceptions.Exit(2)
+        elif not docker_requirements_checker.is_sys_arch_supported():
+            console.error('System architecture is not supported.')
             raise click.exceptions.Exit(2)
         elif not docker_requirements_checker.is_user_permitted():
             console.error('User does not have permissions to run docker.')


### PR DESCRIPTION
Raises an error if the runtime or agents installs are started on unsupported machine architecture.
As the issue is related to the docker requirements, I implemented the check in docker_requirements_checker.py
New supported architectures need to be added to the list of supported architectures.

The architecture is checked with a return value that's based on the kernel implementation of the uname(2)
 system call. So it might be necesarry to handle the same arch with various strings e.g. linux returns x86_64
 or AMD64 on windows.

On mac os, uname returns x86 even on arm64 if the process calling it is running via rosetta. Better parse for ARM
in platform.version() to determine the arch on mac os