### PR TITLE
Check for ip range if it exists or not, before persisting it.

### DIFF
--- a/src/ostorlab/agent/mixins/agent_persist_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_persist_mixin.py
@@ -212,5 +212,5 @@ class AgentPersistMixin:
         if value is not None:
             member_value = value(ip_range)
         else:
-            member_value = ip_network.exploded
+            member_value = ip_range.exploded
         return self.set_add(key, member_value)

--- a/src/ostorlab/agent/mixins/agent_persist_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_persist_mixin.py
@@ -191,7 +191,7 @@ class AgentPersistMixin:
             ip_range: ip range to persist
 
         Returns:
-            returns True if ip_range is added and False if the ip_range or one of his supersets already exits
+            returns True if ip_range is added and False if the ip_range or one of it super nets already exits.
         """
         ip_network = ipaddress.ip_network(ip_range.decode(), strict=False)
         while ip_network.prefixlen > 0:

--- a/src/ostorlab/agent/mixins/agent_persist_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_persist_mixin.py
@@ -13,7 +13,7 @@ Typical usage:
 """
 import ipaddress
 import logging
-from typing import Dict, Set, Callable, Optional
+from typing import Dict, Set, Callable, Optional, Union
 
 import redis
 
@@ -36,7 +36,7 @@ class AgentPersistMixin:
             raise ValueError('agent settings is missing redis url')
         self._redis_client = redis.Redis.from_url(agent_settings.redis_url)
 
-    def set_add(self, key: bytes | str, *value: bytes | str) -> bool:
+    def set_add(self, key: Union[bytes, str], *value: Union[bytes, str]) -> bool:
         """Helper function that takes care of reporting if the specified DNA has been tested in the past, or mark it
         as tested.
         The method can be used to sync multiple agents that may encounter the same test input but need to test it
@@ -52,7 +52,7 @@ class AgentPersistMixin:
         """
         return bool(self._redis_client.sadd(key, *value))
 
-    def set_is_member(self, key: bytes | str, value: bytes | str) -> bool:
+    def set_is_member(self, key: Union[bytes, str], value: Union[bytes, str]) -> bool:
         """Indicates whether value is member of the set identified by key.
 
         Args:
@@ -64,7 +64,7 @@ class AgentPersistMixin:
         """
         return self._redis_client.sismember(key, value)
 
-    def set_len(self, key: bytes | str) -> int:
+    def set_len(self, key: Union[bytes, str]) -> int:
         """Helper function that returns the set cardinality (number of elements) of the set stored at key.
         The method can be used to sync multiple agents that may receive test inputs but need to test
         less than X test inputs.
@@ -78,7 +78,7 @@ class AgentPersistMixin:
         """
         return self._redis_client.scard(key)
 
-    def set_members(self, key: bytes | str) -> Set:
+    def set_members(self, key: Union[bytes, str]) -> Set:
         """Helper function that returns all the members of the set value stored at key.
 
         Args:
@@ -89,7 +89,7 @@ class AgentPersistMixin:
         """
         return self._redis_client.smembers(key)
 
-    def add(self, key: bytes | str, value: bytes) -> bool:
+    def add(self, key: Union[bytes, str], value: bytes) -> bool:
         """Helper function that Set key to hold the string value.
 
         Args:
@@ -101,7 +101,7 @@ class AgentPersistMixin:
         """
         return self._redis_client.set(key, value)
 
-    def get(self, key: bytes | str) -> bytes:
+    def get(self, key: Union[bytes, str]) -> bytes:
         """Get the value of key. If the key does not exist None is returned.
 
         Args:
@@ -112,7 +112,7 @@ class AgentPersistMixin:
         """
         return self._redis_client.get(key)
 
-    def hash_add(self, hash_name: bytes | str, mapping: Dict) -> bool:
+    def hash_add(self, hash_name: Union[bytes, str], mapping: Dict) -> bool:
         """Set mapping within hash hash_name. If hash_name does not exist a new hash is created.
         If key exists, value is overriden.
 
@@ -125,7 +125,7 @@ class AgentPersistMixin:
         """
         return bool(self._redis_client.hset(name=hash_name, mapping=mapping))
 
-    def hash_exists(self, hash_name: bytes | str, key: bytes | str) -> bool:
+    def hash_exists(self, hash_name: Union[bytes, str], key: Union[bytes, str]) -> bool:
         """Returns a boolean indicating if key exists within hash hash_name.
 
         Args:
@@ -137,7 +137,7 @@ class AgentPersistMixin:
         """
         return self._redis_client.hexists(hash_name, key)
 
-    def hash_get(self, hash_name: bytes | str, key: bytes | str):
+    def hash_get(self, hash_name: Union[bytes, str], key: Union[bytes, str]):
         """Return the value of key within the hash hash_name.
 
         Args:
@@ -149,7 +149,7 @@ class AgentPersistMixin:
         """
         return self._redis_client.hget(hash_name, key)
 
-    def hash_get_all(self, hash_name: bytes | str) -> Dict:
+    def hash_get_all(self, hash_name: Union[bytes, str]) -> Dict:
         """Returns a dict of the hash’s name/value pairs.
 
         Args:
@@ -160,7 +160,7 @@ class AgentPersistMixin:
         """
         return self._redis_client.hgetall(hash_name)
 
-    def delete(self, key: bytes | str) -> bool:
+    def delete(self, key: Union[bytes, str]) -> bool:
         """Delete a specific key.
 
         Args:
@@ -171,7 +171,7 @@ class AgentPersistMixin:
         """
         return bool(self._redis_client.delete(key))
 
-    def value_type(self, key: bytes | str) -> str:
+    def value_type(self, key: Union[bytes, str]) -> str:
         """Return a string representation of the type of the value stored at key.
 
         Args:
@@ -182,9 +182,10 @@ class AgentPersistMixin:
         """
         return self._redis_client.type(key).decode()
 
-    def add_ip_network(self, key: bytes | str,
-                       ip_range: ipaddress.IPv6Network | ipaddress.IPv4Network,
-                       value: Optional[Callable[[ipaddress.IPv6Network | ipaddress.IPv4Network], bytes | str]] = None
+    def add_ip_network(self, key: Union[bytes, str],
+                       ip_range: Union[ipaddress.IPv6Network, ipaddress.IPv4Network],
+                       value: Optional[
+                           Callable[[Union[ipaddress.IPv6Network, ipaddress.IPv4Network]], Union[bytes, str]]] = None
                        ) -> bool:
         """
         Returns True if a network have never been persisted before, else it's returns False

--- a/src/ostorlab/apis/runners/authenticated_runner.py
+++ b/src/ostorlab/apis/runners/authenticated_runner.py
@@ -153,4 +153,4 @@ class AuthenticatedAPIRunner(runner.APIRunner):
             proxy = None
 
         return requests.post(self.endpoint, data=request.data, files=request.files, headers=headers,
-                             proxies=proxy, verify=self._verify,timeout=10)
+                             proxies=proxy, verify=self._verify, timeout=runner.REQUEST_TIMEOUT)

--- a/src/ostorlab/apis/runners/authenticated_runner.py
+++ b/src/ostorlab/apis/runners/authenticated_runner.py
@@ -153,4 +153,4 @@ class AuthenticatedAPIRunner(runner.APIRunner):
             proxy = None
 
         return requests.post(self.endpoint, data=request.data, files=request.files, headers=headers,
-                             proxies=proxy, verify=self._verify)
+                             proxies=proxy, verify=self._verify,timeout=10)

--- a/src/ostorlab/apis/runners/public_runner.py
+++ b/src/ostorlab/apis/runners/public_runner.py
@@ -55,4 +55,4 @@ class PublicAPIRunner(runner.APIRunner):
         else:
             proxy = None
         return requests.post(self.endpoint, data=request.data,
-                             proxies=proxy, verify=self._verify)
+                             proxies=proxy, verify=self._verify,timeout=10)

--- a/src/ostorlab/apis/runners/public_runner.py
+++ b/src/ostorlab/apis/runners/public_runner.py
@@ -55,4 +55,4 @@ class PublicAPIRunner(runner.APIRunner):
         else:
             proxy = None
         return requests.post(self.endpoint, data=request.data,
-                             proxies=proxy, verify=self._verify,timeout=10)
+                             proxies=proxy, verify=self._verify, timeout=runner.REQUEST_TIMEOUT)

--- a/src/ostorlab/apis/runners/runner.py
+++ b/src/ostorlab/apis/runners/runner.py
@@ -11,6 +11,8 @@ import requests
 from ostorlab import configuration_manager as config_manager
 from ostorlab.apis import request as api_request
 
+REQUEST_TIMEOUT = 10
+
 
 class Error(Exception):
     """Base Error Class"""
@@ -66,4 +68,4 @@ class APIRunner(abc.ABC):
             proxy = None
 
         return requests.post(self.endpoint, data=request.data, files=request.files, headers=headers,
-                             proxies=proxy, verify=self._verify, timeout=10)
+                             proxies=proxy, verify=self._verify, timeout=REQUEST_TIMEOUT)

--- a/src/ostorlab/apis/runners/runner.py
+++ b/src/ostorlab/apis/runners/runner.py
@@ -5,6 +5,7 @@ This module also has classes for authentication errors, API response errors, etc
 
 import abc
 from typing import Dict
+
 import requests
 
 from ostorlab import configuration_manager as config_manager
@@ -34,7 +35,6 @@ class APIRunner(abc.ABC):
         self._proxy = proxy
         self._verify = verify
         self._configuration_manager: config_manager.ConfigurationManager = config_manager.ConfigurationManager()
-
 
     @property
     def endpoint(self) -> str:
@@ -66,4 +66,4 @@ class APIRunner(abc.ABC):
             proxy = None
 
         return requests.post(self.endpoint, data=request.data, files=request.files, headers=headers,
-                             proxies=proxy, verify=self._verify)
+                             proxies=proxy, verify=self._verify, timeout=10)

--- a/src/ostorlab/cli/agent/healthcheck/healthcheck.py
+++ b/src/ostorlab/cli/agent/healthcheck/healthcheck.py
@@ -1,8 +1,8 @@
 """Agent Healthcheck commands."""
-import requests
 import logging
 
 import click
+import requests
 
 from ostorlab.cli import console as cli_console
 from ostorlab.cli.agent import agent
@@ -24,7 +24,7 @@ def healthcheck(host: str, port: int, https: bool = False) -> None:
         url = f'http://{host}:{port}/status'
 
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         if response.status_code != 200:
             console.error(f'Response status code is {response.status_code}')
             raise click.exceptions.Exit(2)

--- a/tests/agent/mixins/agent_healthcheck_mixin_test.py
+++ b/tests/agent/mixins/agent_healthcheck_mixin_test.py
@@ -12,7 +12,7 @@ def testHealthcheckAgentMixin_whenHealthcheckCallbackReturnsTrue_statusReturnsOK
     status_agent.add_healthcheck(lambda: True)
     status_agent.start_healthcheck()
     time.sleep(0.5)
-    response = requests.get('http://127.0.1.2:5006/status')
+    response = requests.get('http://127.0.1.2:5006/status', timeout=10)
     assert response.status_code == 200
     assert response.content == b'OK'
     status_agent.stop_healthcheck()
@@ -24,7 +24,7 @@ def testHealthcheckAgentMixin_whenHealthcheckCallbackReturnsFalse_statusReturnsN
     status_agent.add_healthcheck(lambda: False)
     status_agent.start_healthcheck()
     time.sleep(0.5)
-    response = requests.get('http://127.0.1.3:5006/status')
+    response = requests.get('http://127.0.1.3:5006/status', timeout=10)
     assert response.status_code == 200
     assert response.content == b'NOK'
     status_agent.stop_healthcheck()
@@ -38,7 +38,7 @@ def testHealthcheckAgentMixin_whenMultipleHealthcheckCallbacksAndOneReturnsFalse
     status_agent.add_healthcheck(lambda: True)
     status_agent.start_healthcheck()
     time.sleep(0.5)
-    response = requests.get('http://127.0.1.4:5006/status')
+    response = requests.get('http://127.0.1.4:5006/status', timeout=10)
     assert response.status_code == 200
     assert response.content == b'NOK'
     status_agent.stop_healthcheck()

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -42,7 +42,7 @@ async def testAgentPersistMixinDeleteKey_whenKeyExists_keyIsDeleted(mocker, redi
 
     mixin.set_add('test1', b'A')
     mixin.delete('test1')
-    assert mixin.set_members('test')  == set()
+    assert mixin.set_members('test') == set()
 
 
 @pytest.mark.parametrize('clean_redis_data', ['redis://localhost:6379'], indirect=True)
@@ -61,3 +61,19 @@ async def testAgentPersistMixin_whenHashIsAdded_hashIsPersisted(mocker, redis_se
     assert mixin.hash_get('hash_name', 'NoneExistingKey') is None
     assert b'key1' in mixin.hash_get_all('hash_name')
     assert b'key2' in mixin.hash_get_all('hash_name')
+
+
+@pytest.mark.parametrize('clean_redis_data', ['redis://localhost:6379'], indirect=True)
+@pytest.mark.asyncio
+@pytest.mark.docker
+async def testAgentPersistMixinCheckIpRangeExist_WhenIpRangeIsSaned_ReturnTrue(mocker, redis_service, clean_redis_data):
+    """Test mixin.add_ip_range returns True if ip_range is added and False if the ip_range or one of his supersets already exits """
+    del mocker, redis_service, clean_redis_data
+    settings = runtime_definitions.AgentSettings(key='agent/ostorlab/debug', redis_url='redis://localhost:6379')
+    mixin = agent_persist_mixin.AgentPersistMixin(settings)
+
+    assert mixin.add_ip_range(b'test_ip', b'8.8.8.0/23') is True
+    assert mixin.add_ip_range(b'test_ip', b'8.8.8.0/24') is False
+    assert mixin.add_ip_range(b'test_ip', b'8.8.8.0/32') is False
+    assert mixin.add_ip_range(b'test_ip', b'10.10.10.0/23') is True
+    assert mixin.add_ip_range(b'test_ip', b'10.10.10.0/28') is False

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -68,7 +68,8 @@ async def testAgentPersistMixin_whenHashIsAdded_hashIsPersisted(mocker, redis_se
 @pytest.mark.asyncio
 @pytest.mark.docker
 async def testAgentPersistMixinCheckIpRangeExist_WhenIpRangeIsSaned_ReturnTrue(mocker, redis_service, clean_redis_data):
-    """Test mixin.add_ip_network returns True if ip_range is added and False if the ip_range or one of his supersets already exits """
+    """Test mixin.add_ip_network returns True if ip_range is added and False if the ip_range
+    or one of his supersets already exits """
     del mocker, redis_service, clean_redis_data
     settings = runtime_definitions.AgentSettings(key='agent/ostorlab/debug', redis_url='redis://localhost:6379')
     mixin = agent_persist_mixin.AgentPersistMixin(settings)

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -1,4 +1,5 @@
 """Tests for AgentPersistMixin module."""
+import ipaddress
 
 import pytest
 
@@ -67,13 +68,15 @@ async def testAgentPersistMixin_whenHashIsAdded_hashIsPersisted(mocker, redis_se
 @pytest.mark.asyncio
 @pytest.mark.docker
 async def testAgentPersistMixinCheckIpRangeExist_WhenIpRangeIsSaned_ReturnTrue(mocker, redis_service, clean_redis_data):
-    """Test mixin.add_ip_range returns True if ip_range is added and False if the ip_range or one of his supersets already exits """
+    """Test mixin.add_ip_network returns True if ip_range is added and False if the ip_range or one of his supersets already exits """
     del mocker, redis_service, clean_redis_data
     settings = runtime_definitions.AgentSettings(key='agent/ostorlab/debug', redis_url='redis://localhost:6379')
     mixin = agent_persist_mixin.AgentPersistMixin(settings)
 
-    assert mixin.add_ip_range(b'test_ip', b'8.8.8.0/23') is True
-    assert mixin.add_ip_range(b'test_ip', b'8.8.8.0/24') is False
-    assert mixin.add_ip_range(b'test_ip', b'8.8.8.0/32') is False
-    assert mixin.add_ip_range(b'test_ip', b'10.10.10.0/23') is True
-    assert mixin.add_ip_range(b'test_ip', b'10.10.10.0/28') is False
+    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('8.8.8.0/23')) is True
+    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('8.8.8.0/24')) is False
+    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('8.8.8.0/23')) is False
+    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('8.8.8.0/24')) is False
+    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('8.8.8.0/31')) is False
+    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('10.10.10.0/23')) is True
+    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('10.10.10.0/28')) is False

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -67,7 +67,8 @@ async def testAgentPersistMixin_whenHashIsAdded_hashIsPersisted(mocker, redis_se
 @pytest.mark.parametrize('clean_redis_data', ['redis://localhost:6379'], indirect=True)
 @pytest.mark.asyncio
 @pytest.mark.docker
-async def testAgentPersistMixinCheckIpRangeExist_whenIpRangeIsCovered_returnTrue(mocker, redis_service, clean_redis_data):
+async def testAgentPersistMixinCheckIpRangeExist_whenIpRangeIsCovered_returnTrue(mocker, redis_service,
+                                                                                 clean_redis_data):
     """Test mixin.add_ip_network returns True if ip_range is added and False if the ip_range
     or one of his supersets already exits """
     del mocker, redis_service, clean_redis_data
@@ -82,6 +83,7 @@ async def testAgentPersistMixinCheckIpRangeExist_whenIpRangeIsCovered_returnTrue
     assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/22')) is True
     assert mixin.add_ip_network('test_ip', ipaddress.ip_network('10.10.10.0/23')) is True
     assert mixin.add_ip_network('test_ip', ipaddress.ip_network('10.10.10.0/28')) is False
+
 
 @pytest.mark.parametrize('clean_redis_data', ['redis://localhost:6379'], indirect=True)
 @pytest.mark.asyncio
@@ -101,4 +103,3 @@ async def testAgentPersistMixinCheckIpRangeExist_withCallableKey_returnTrue(mock
     assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/22'), lambda net: f'X_{net}_Y') is True
     assert mixin.add_ip_network('test_ip', ipaddress.ip_network('10.10.10.0/23'), lambda net: f'X_{net}_Y') is True
     assert mixin.add_ip_network('test_ip', ipaddress.ip_network('10.10.10.0/28'), lambda net: f'X_{net}_Y') is False
-

--- a/tests/agent/mixins/agent_persist_mixin_test.py
+++ b/tests/agent/mixins/agent_persist_mixin_test.py
@@ -67,17 +67,38 @@ async def testAgentPersistMixin_whenHashIsAdded_hashIsPersisted(mocker, redis_se
 @pytest.mark.parametrize('clean_redis_data', ['redis://localhost:6379'], indirect=True)
 @pytest.mark.asyncio
 @pytest.mark.docker
-async def testAgentPersistMixinCheckIpRangeExist_WhenIpRangeIsSaned_ReturnTrue(mocker, redis_service, clean_redis_data):
+async def testAgentPersistMixinCheckIpRangeExist_whenIpRangeIsCovered_returnTrue(mocker, redis_service, clean_redis_data):
     """Test mixin.add_ip_network returns True if ip_range is added and False if the ip_range
     or one of his supersets already exits """
     del mocker, redis_service, clean_redis_data
     settings = runtime_definitions.AgentSettings(key='agent/ostorlab/debug', redis_url='redis://localhost:6379')
     mixin = agent_persist_mixin.AgentPersistMixin(settings)
 
-    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('8.8.8.0/23')) is True
-    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('8.8.8.0/24')) is False
-    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('8.8.8.0/23')) is False
-    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('8.8.8.0/24')) is False
-    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('8.8.8.0/31')) is False
-    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('10.10.10.0/23')) is True
-    assert mixin.add_ip_network(b'test_ip', ipaddress.ip_network('10.10.10.0/28')) is False
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/23')) is True
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/24')) is False
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/23')) is False
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/24')) is False
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/31')) is False
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/22')) is True
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('10.10.10.0/23')) is True
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('10.10.10.0/28')) is False
+
+@pytest.mark.parametrize('clean_redis_data', ['redis://localhost:6379'], indirect=True)
+@pytest.mark.asyncio
+@pytest.mark.docker
+async def testAgentPersistMixinCheckIpRangeExist_withCallableKey_returnTrue(mocker, redis_service, clean_redis_data):
+    """Test mixin.add_ip_network returns True if ip_range is added and False if the ip_range
+    or one of his supersets already exits """
+    del mocker, redis_service, clean_redis_data
+    settings = runtime_definitions.AgentSettings(key='agent/ostorlab/debug', redis_url='redis://localhost:6379')
+    mixin = agent_persist_mixin.AgentPersistMixin(settings)
+
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/23'), lambda net: f'X_{net}_Y') is True
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/24'), lambda net: f'X_{net}_Y') is False
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/23'), lambda net: f'X_{net}_Y') is False
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/24'), lambda net: f'X_{net}_Y') is False
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/31'), lambda net: f'X_{net}_Y') is False
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('8.8.8.0/22'), lambda net: f'X_{net}_Y') is True
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('10.10.10.0/23'), lambda net: f'X_{net}_Y') is True
+    assert mixin.add_ip_network('test_ip', ipaddress.ip_network('10.10.10.0/28'), lambda net: f'X_{net}_Y') is False
+


### PR DESCRIPTION
If an agent is scanning IP range , we need somehow to keep track of which range we scanned before. persisting each single ip in Redis is not a good idea.
in this PR i add `add_ip_range` Method,
the method returns True if IP range is added and False if the ip range or one of his super nets already scanned.
