### PR TITLE
Fix: Bug in agent group json format

### DIFF
--- a/.github/workflows/python-package-lint.yml
+++ b/.github/workflows/python-package-lint.yml
@@ -42,3 +42,4 @@ jobs:
         mypy src/ostorlab/agent/kb
         mypy src/ostorlab/agent/message
         mypy src/ostorlab/utils
+        mypy src/ostorlab/agent/schema

--- a/src/ostorlab/agent/schema/agent_group_schema.json
+++ b/src/ostorlab/agent/schema/agent_group_schema.json
@@ -34,7 +34,8 @@
           "description": "[Optional] - Default value of the agent argument.",
           "type": ["string", "number", "boolean", "array", "object"]
         }
-      }
+      },
+      "required": ["name", "type"]
     },
     "agentPortMapping": {
       "description": "[Optional] - Array of dictionary-like objects, defining the port mapping.",
@@ -103,7 +104,8 @@
             "type": "array",
             "items": {
               "$ref": "#/CustomTypes/agentArgument"
-            }
+            },
+            "default": []
           },
           "port_mapping": {
             "description": "[Optional] - List of the agent port mapping.",
@@ -120,7 +122,8 @@
               "maxLength": 4096
             }
           }
-        }
+        },
+        "required": ["key"]
       }
     }
   },

--- a/src/ostorlab/agent/schema/agent_schema.json
+++ b/src/ostorlab/agent/schema/agent_schema.json
@@ -170,7 +170,8 @@
             "description": "[Optional] - Default value of the agent argument.",
             "type": ["string", "number", "boolean", "array", "object"]
           }
-        }
+        },
+        "required": ["name", "type"]
       }
     }
   },

--- a/src/ostorlab/agent/schema/loader.py
+++ b/src/ostorlab/agent/schema/loader.py
@@ -37,7 +37,7 @@ def load_agent_yaml(file: io.TextIOWrapper) -> Dict[str, Any]:
     return _load_spec_yaml(file, spec)
 
 
-def load_agent_group_yaml(file: io.TextIOWrapper) -> object:
+def load_agent_group_yaml(file: io.TextIOWrapper) -> Dict[str, Any]:
     """Loads and validates agent gorup yaml definition file.
 
     Args:

--- a/tests/agent/kb/kb_test.py
+++ b/tests/agent/kb/kb_test.py
@@ -4,7 +4,7 @@ import pytest
 from ostorlab.agent.kb import kb
 
 
-def testkbGetAttribute_whenMappingExists_returnsEntry():
+def testkbGetAttribute_whenMappingExists_returnsEntry() -> None:
     """Test KB resolves correctly and returns a valid entry."""
     entry = kb.KB.WEB_XSS
 
@@ -15,7 +15,7 @@ def testkbGetAttribute_whenMappingExists_returnsEntry():
     assert entry.recommendation is not None
 
 
-def testkbGetAttribute_whenMappingDoNotExists_raisesValueError():
+def testkbGetAttribute_whenMappingDoNotExists_raisesValueError() -> None:
     """Test KB resolution fails with a `ValueError`."""
     with pytest.raises(ValueError):
         _ = kb.KB.RANDOM_FAKE_KEY

--- a/tests/agent/schema/test_loader.py
+++ b/tests/agent/schema/test_loader.py
@@ -21,10 +21,10 @@ def testAgentSpecValidation_whenDefinitionIsCorrect_noRaise():
         image: "some/path/to/the/image"
         source: "https://github.com/"
         durability: "development"
-        restrictions: 
+        restrictions:
         - "restriction1"
         - "restriction2"
-        in_selectors: 
+        in_selectors:
         - "in_selector1"
         - "in_selector2"
         out_selectors:
@@ -71,10 +71,10 @@ def testAgentSpecValidation_whenVersionDoesNotRespectSemanticVersionning_raiseVa
         image: "some/path/to/the/image"
         source: "https://github.com/"
         durability: "development"
-        restrictions: 
+        restrictions:
         - "restriction1"
         - "restriction2"
-        in_selectors: 
+        in_selectors:
         - "in_selector1"
         - "in_selector2"
         out_selectors:
@@ -121,17 +121,23 @@ def testAgentGroupSpecValidation_whenDefinitionIsCorrect_noRaise():
         constraints:
         - "constraint1"
         - "constraint2"
-        
+
         agents:
             - name: "AgentBigFuzzer"
+              key: agent/testorg/bigfuzzer
               args:
                - color: "red"
-                 speed: "slow" 
+                 speed: "slow"
+                 name: "arg1"
+                 type: "string"
             - name: "AgentSmallFuzzer"
+              key: agent/testorg/smallfuzzer
               args:
                - color: "blue"
                  speed: "fast"
-        
+                 name: "arg2"
+                 type: "string"
+
         agentGroupArgument:
             - name: "agentGroupArgumentExample1"
               type: ["string", "number", "boolean"]
@@ -140,7 +146,7 @@ def testAgentGroupSpecValidation_whenDefinitionIsCorrect_noRaise():
             - name: "agentGroupArgumentExample2"
               type: ["string", "number", "boolean"]
               description: "agentGroupArgumentDescription2"
-              value: 42   
+              value: 42
     """
     yaml_data_file = io.StringIO(valid_yaml_agent_group_data)
 
@@ -155,7 +161,7 @@ def testAgentGroupSpecValidation_whenRequiredParamDescriptionIsMissing_raiseVali
     """
 
     invalid_yaml_agent_group_data = """
-        kind: "AgentGroup1"
+        kind: "AgentGroup"
         image: "some/path/to/the/image"
         restart_policy: "any"
         restrictions:
@@ -164,20 +170,26 @@ def testAgentGroupSpecValidation_whenRequiredParamDescriptionIsMissing_raiseVali
         constraints:
         - "constraint1"
         - "constraint2"
-        
+
         agents:
             - name: "AgentBigFuzzer"
+              key: agent/testorg/bigfuzzer
               args:
                - color: "red"
-                 speed: "slow" 
+                 speed: "slow"
+                 name: "arg1"
+                 type: "string"
             - name: "AgentSmallFuzzer"
+              key: agent/testorg/smallfuzzer
               args:
                - color: "blue"
                  speed: "fast"
+                 name: "arg2"
+                 type: "string"
 
         agentGroupArgument:
             - name: "agentGroupArgumentExample1"
-              type: "string"
+              type: ["string", "number", "boolean"]
               description: "agentGroupArgumentDescription1"
               value: "agentGroupArgumentValue1"
             - name: "agentGroupArgumentExample2"

--- a/tests/agent/schema/test_loader.py
+++ b/tests/agent/schema/test_loader.py
@@ -161,7 +161,7 @@ def testAgentGroupSpecValidation_whenRequiredParamDescriptionIsMissing_raiseVali
     """
 
     invalid_yaml_agent_group_data = """
-        kind: "AgentGroup"
+        kind: "AgentGroup1"
         image: "some/path/to/the/image"
         restart_policy: "any"
         restrictions:
@@ -193,7 +193,7 @@ def testAgentGroupSpecValidation_whenRequiredParamDescriptionIsMissing_raiseVali
               description: "agentGroupArgumentDescription1"
               value: "agentGroupArgumentValue1"
             - name: "agentGroupArgumentExample2"
-              type: ["string", "number", "boolean"]
+              type: "string"
               description: "agentGroupArgumentDescription2"
               value: 42
 

--- a/tests/agent/schema/test_loader.py
+++ b/tests/agent/schema/test_loader.py
@@ -8,7 +8,7 @@ from ostorlab.agent.schema import loader
 from ostorlab.agent.schema import validator
 
 
-def testAgentSpecValidation_whenDefinitionIsCorrect_noRaise():
+def testAgentSpecValidation_whenDefinitionIsCorrect_noRaise() -> None:
     """Unit test to check the validity of the Agent json-schema.
     Case where the Agent definition is valid.
     """
@@ -58,7 +58,7 @@ def testAgentSpecValidation_whenDefinitionIsCorrect_noRaise():
     assert data['agenArgument'][1]['default_value'] == 42
 
 
-def testAgentSpecValidation_whenVersionDoesNotRespectSemanticVersionning_raiseValidationError():
+def testAgentSpecValidation_whenVersionDoesNotRespectSemanticVersionning_raiseValidationError() -> None:
     """Unit test to checks the validity of the Agent json-schema.
     Case where the Agent definition is invalid.
     The version does not respect the semantic versionning : major.minor.release.
@@ -105,7 +105,7 @@ def testAgentSpecValidation_whenVersionDoesNotRespectSemanticVersionning_raiseVa
         loader.load_agent_yaml(yaml_data_file)
 
 
-def testAgentGroupSpecValidation_whenDefinitionIsCorrect_noRaise():
+def testAgentGroupSpecValidation_whenDefinitionIsCorrect_noRaise() -> None:
     """Unit test to checks the validity of the AgentGroup json-schema.
     Case where the AgentGroup definition is valid.
     """
@@ -155,7 +155,7 @@ def testAgentGroupSpecValidation_whenDefinitionIsCorrect_noRaise():
     assert data['description'] == 'AgentGroup1 Should be here'
 
 
-def testAgentGroupSpecValidation_whenRequiredParamDescriptionIsMissing_raiseValidationError():
+def testAgentGroupSpecValidation_whenRequiredParamDescriptionIsMissing_raiseValidationError() -> None:
     """Unit test to checks the validity of the AgentGroup json-schema.
     Case where the AgentGroup definition is invalid : Required parameter description is missing.
     """

--- a/tests/agent/schema/test_validator.py
+++ b/tests/agent/schema/test_validator.py
@@ -7,7 +7,7 @@ import pytest
 from ostorlab.agent.schema import validator
 
 
-def testYamlValidation_whenItIsCorrect_noRaise(json_schema_file):
+def testYamlValidation_whenItIsCorrect_noRaise(json_schema_file: io.StringIO) -> None:
     """Unit test for the method that validates a yaml configuration file against a json schema.
     Case where the yaml configuration file is valid.
     """
@@ -46,7 +46,7 @@ def testYamlValidation_whenItIsCorrect_noRaise(json_schema_file):
             pytest.fail("SchemaError shouldn't be expected.")
 
 
-def testYamlValidation_whenArgsAreMissingAnyRequiredFiled_raisesValidationError(json_schema_file):
+def testYamlValidation_whenArgsAreMissingAnyRequiredFiled_raisesValidationError(json_schema_file: io.StringIO) -> None:
     """Unit test for the method that validates an agent group yaml configuration file against a json schema.
     Case where the yaml configuration file is valid.
     """
@@ -84,7 +84,7 @@ def testYamlValidation_whenArgsAreMissingAnyRequiredFiled_raisesValidationError(
     assert exc_info.type is validator.ValidationError
 
 
-def testAgentGroupYamlValidation_whenItIsCorrect_noRaise(agent_group_json_schema_file):
+def testAgentGroupYamlValidation_whenItIsCorrect_noRaise(agent_group_json_schema_file: io.StringIO) -> None:
     """Unit test for the method that validates a yaml configuration file against a json schema.
     Case where the yaml configuration file is invalid (args are missing required fields).
     """
@@ -109,7 +109,8 @@ def testAgentGroupYamlValidation_whenItIsCorrect_noRaise(agent_group_json_schema
             pytest.fail("SchemaError shouldn't be expected.")
 
 
-def testAgentGroupYamlValidation_whenAgentArgsAreWrongAndAgentKeyIsMissing_raisesValidationError(agent_group_json_schema_file):
+def testAgentGroupYamlValidation_whenAgentArgsAreWrongAndAgentKeyIsMissing_raisesValidationError(
+        agent_group_json_schema_file: io.StringIO) -> None:
     """Unit test for the method that validates an agent group yaml configuration file against a json schema.
     Case where the yaml configuration file is invalid (agent args are wrong and key is missing).
     """
@@ -132,7 +133,8 @@ def testAgentGroupYamlValidation_whenAgentArgsAreWrongAndAgentKeyIsMissing_raise
     assert exc_info.type is validator.ValidationError
 
 
-def testYamlValidation_whenSourceParamDoesNotRespectURLPattern_raisesValidationError(json_schema_file):
+def testYamlValidation_whenSourceParamDoesNotRespectURLPattern_raisesValidationError(
+        json_schema_file: io.StringIO) -> None:
     """Unit test for the method that validates a yaml configuration file against a json schema.
     Case where the yaml configuration file is invalid : The parameter 'source' should be a URL instead of a number.
     """
@@ -163,7 +165,7 @@ def testYamlValidation_whenSourceParamDoesNotRespectURLPattern_raisesValidationE
     assert exc_info.type is validator.ValidationError
 
 
-def testValidatorInit_whenSchemaIsInvalidTypeParamIsMisspelled_raisesSchemaError():
+def testValidatorInit_whenSchemaIsInvalidTypeParamIsMisspelled_raisesSchemaError() -> None:
     """Unit test for the init of the validator class with a invalid schema.
     The type is misspelled : 'strg' instead of 'string'.
     """
@@ -182,5 +184,4 @@ def testValidatorInit_whenSchemaIsInvalidTypeParamIsMisspelled_raisesSchemaError
 
     with pytest.raises(validator.SchemaError) as exc_info:
         _ = validator.Validator(json_schema_file_object)
-
-    assert exc_info.type is validator.SchemaError
+        assert exc_info.type is validator.SchemaError

--- a/tests/agent/schema/test_validator.py
+++ b/tests/agent/schema/test_validator.py
@@ -18,16 +18,21 @@ def testYamlValidation_whenItIsCorrect_noRaise(json_schema_file):
         image: "some/path/to/the/image"
         source: "https://github.com/"
         durability: "development"
-        restrictions: 
+        restrictions:
         - "restriction1"
         - "restriction2"
-        in_selectors: 
+        in_selectors:
         - "in_selector1"
         - "in_selector2"
         out_selectors:
         - "out_selector1"
         - "out_selector2"
         restart_policy: "none"
+        args:
+        - name: port
+          type: number
+        - name: schema
+          type: string
     """
 
     with io.StringIO(valid_yaml_data) as yaml_data_file:
@@ -41,6 +46,92 @@ def testYamlValidation_whenItIsCorrect_noRaise(json_schema_file):
             pytest.fail("SchemaError shouldn't be expected.")
 
 
+def testYamlValidation_whenArgsAreMissingAnyRequiredFiled_raisesValidationError(json_schema_file):
+    """Unit test for the method that validates an agent group yaml configuration file against a json schema.
+    Case where the yaml configuration file is valid.
+    """
+
+    invalid_yaml_data = """
+        name: "Agent1"
+        description: "Agent1 Description should be here"
+        image: "some/path/to/the/image"
+        source: 3
+        durability: "development"
+        restrictions:
+        - "restriction1"
+        - "restriction2"
+        in_selectors:
+        - "in_selector1"
+        - "in_selector2"
+        out_selectors:
+        - "out_selector1"
+        - "out_selector2"
+        restart_policy: "none"
+        args:
+        - name: port
+          description: "Target that doesn't specify port will use this argument to set the target port."
+          value: 443
+        - type: string
+          description: "Target that doesn't specify a schema will use this argument."
+          value: https
+    """
+    validator_object = validator.Validator(json_schema_file)
+    yaml_data_file = io.StringIO(invalid_yaml_data)
+
+    with pytest.raises(validator.ValidationError) as exc_info:
+        validator_object.validate(yaml_data_file)
+
+    assert exc_info.type is validator.ValidationError
+
+
+def testAgentGroupYamlValidation_whenItIsCorrect_noRaise(agent_group_json_schema_file):
+    """Unit test for the method that validates a yaml configuration file against a json schema.
+    Case where the yaml configuration file is invalid (args are missing required fields).
+    """
+
+    valid_yaml_data = """
+        kind: "AgentGroup"
+        description: "Agent group definition for asset autodiscovery."
+        agents:
+        - args: [{name: "arg1", type: string}]
+          key: agent/ostorlab/whatweb
+        - args: []
+          key: agent/ostorlab/wappalyzer
+    """
+    with io.StringIO(valid_yaml_data) as yaml_data_file:
+        validator_object = validator.Validator(agent_group_json_schema_file)
+
+        try:
+            validator_object.validate(yaml_data_file)
+        except validator.ValidationError:
+            pytest.fail("ValidationError shouldn't be expected.")
+        except validator.SchemaError:
+            pytest.fail("SchemaError shouldn't be expected.")
+
+
+def testAgentGroupYamlValidation_whenAgentArgsAreWrongAndAgentKeyIsMissing_raisesValidationError(agent_group_json_schema_file):
+    """Unit test for the method that validates an agent group yaml configuration file against a json schema.
+    Case where the yaml configuration file is invalid (agent args are wrong and key is missing).
+    """
+
+    invalid_yaml_data = """
+        kind: "AgentGroup"
+        description: "Agent group definition for asset autodiscovery."
+        agents:
+        - args: [{name: "arg1"}]
+        - args: [{type: "number"}]
+          key: agent/ostorlab/wappalyzer
+    """
+
+    validator_object = validator.Validator(agent_group_json_schema_file)
+    yaml_data_file = io.StringIO(invalid_yaml_data)
+
+    with pytest.raises(validator.ValidationError) as exc_info:
+        validator_object.validate(yaml_data_file)
+
+    assert exc_info.type is validator.ValidationError
+
+
 def testYamlValidation_whenSourceParamDoesNotRespectURLPattern_raisesValidationError(json_schema_file):
     """Unit test for the method that validates a yaml configuration file against a json schema.
     Case where the yaml configuration file is invalid : The parameter 'source' should be a URL instead of a number.
@@ -52,10 +143,10 @@ def testYamlValidation_whenSourceParamDoesNotRespectURLPattern_raisesValidationE
         image: "some/path/to/the/image"
         source: 3
         durability: "development"
-        restrictions: 
+        restrictions:
         - "restriction1"
         - "restriction2"
-        in_selectors: 
+        in_selectors:
         - "in_selector1"
         - "in_selector2"
         out_selectors:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,9 +100,94 @@ def json_schema_file():
                 },
                 "mem_limit":{
                     "type": "number"
+                },
+                "args": {
+                    "description": "[Optional] - Array of dictionary-like objects, defining the agent arguments.",
+                    "type": "array",
+                    "items": {
+                        "description": "Dictionary-like object of the argument.",
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "description": "[Required] - Name of the agent argument.",
+                                "type": "string",
+                                "maxLength": 2048
+                            },
+                            "type": {
+                                "description": "[Required] - Type of the agent argument : respecting the jsonschema types.",
+                                "type": "string",
+                                "maxLength": 2048
+                            }
+                        },
+                        "required": ["name", "type"]
+                    }
                 }
             },
-            "required": ["name", "image", "source", "durability", "restrictions", "in_selectors", "out_selectors", "restart_policy"]
+            "required": ["name", "image", "source", "durability", "restrictions", "in_selectors", "out_selectors", "restart_policy", "args"]
+        }
+
+    """
+    json_schema_file_object = io.StringIO(json_schema)
+    return json_schema_file_object
+
+
+@pytest.fixture
+def agent_group_json_schema_file():
+    """Agent group json schema is made a fixture since it will be used by multiple unit tests.
+
+    Returns:
+      json_schema_file_object : a file object of the agent group json schema file.
+
+    """
+    json_schema = """
+        {
+            "CustomTypes": {
+                "agentArgument": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "maxLength": 2048
+                        },
+                        "type": {
+                            "type": "string",
+                            "maxLength": 2048
+                        }
+                    },
+                    "required": ["name", "type"]
+                }
+            },
+            "properties": {
+                "description":{
+                    "type": "string"
+                },
+                "kind":{
+                    "type": "string",
+                    "enum": [
+                        "AgentGroup"
+                    ]
+                },
+                "agents": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "args": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/CustomTypes/agentArgument"
+                                },
+                                "default": []
+                            }
+                        },
+                        "required": ["key", "args"]
+                    }
+                }
+            },
+            "required": ["kind", "description", "agents"]
         }
 
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def redis_service():
 
 
 @pytest.fixture
-def json_schema_file():
+def json_schema_file() -> io.StringIO:
     """Json schema is made a fixture since it will be used by multiple unit tests.
 
     Returns:
@@ -132,7 +132,7 @@ def json_schema_file():
 
 
 @pytest.fixture
-def agent_group_json_schema_file():
+def agent_group_json_schema_file() -> io.StringIO:
     """Agent group json schema is made a fixture since it will be used by multiple unit tests.
 
     Returns:


### PR DESCRIPTION
- Makes changes to the agent group schema to mark the `key` of each agent as required.
- Defaults the agent `args` to an empty list.
- Marks `name` and `type` as required in the agent schema.