### PR TITLE
Fix minifier

### DIFF
--- a/src/ostorlab/agent/mixins/agent_open_telemetry_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_open_telemetry_mixin.py
@@ -13,6 +13,7 @@ import tempfile
 import uuid
 from typing import Any, Dict, Optional
 from urllib import parse
+import copy
 
 from opentelemetry import trace
 from opentelemetry.exporter import cloud_trace
@@ -229,7 +230,8 @@ class OpenTelemetryMixin:
 
                 emit_span.set_attribute('agent.name', self.name)
                 emit_span.set_attribute('message.selector', selector)
-                minified_msg_data = dictionary_minifier.minify_dict(data, dictionary_minifier.truncate_str)
+                cloned_data = copy.deepcopy(data)
+                minified_msg_data = dictionary_minifier.minify_dict(cloned_data, dictionary_minifier.truncate_str)
                 emit_span.set_attribute('message.data', json.dumps(minified_msg_data))
 
                 super().emit(selector, data, f'{message_id or uuid.uuid4()}-{trace_id}-{span_id}')

--- a/tests/agent/mixins/agent_open_telemetry_test.py
+++ b/tests/agent/mixins/agent_open_telemetry_test.py
@@ -59,8 +59,8 @@ def testOpenTelemetryMixin_whenEmitMessage_shouldTraceMessage(agent_run_mock: ag
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='does not run on windows')
 def testOpenTelemetryMixin_whenEmitMessage_shouldNotTruncateOriginalMessage(
-            agent_run_mock: agent_testing.AgentRunInstance
-    ) -> None:
+        agent_run_mock: agent_testing.AgentRunInstance
+) -> None:
     """Unit test for the OpenTelemetry Mixin, ensure the correct exporter has been used and trace span has been sent."""
     with tempfile.NamedTemporaryFile(suffix='.json') as tmp_file_obj:
         agent_definition = agent_definitions.AgentDefinition(
@@ -73,7 +73,7 @@ def testOpenTelemetryMixin_whenEmitMessage_shouldNotTruncateOriginalMessage(
             agent_definition=agent_definition,
             agent_settings=agent_settings)
 
-        technical_detail = """Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum 
+        technical_detail = """Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
         has been the standard dummy text ever since the 1500s, when an unknown printer took a galley of type and 
         scrambled it to make a type specimen book. when an unknown printer took a galley of type and scrambled it to 
         make a type specimen book. """
@@ -167,4 +167,3 @@ def testOpenTelemetryMixin_whenProcessMessageWithTraceIdSpanId_shouldInjectIdInC
             assert trace_object['attributes']['message.selector'] == 'v3.report.vulnerability'
             processed_msg = '{"title": "some_title", "risk_rating": "MEDIUM", "technical_detail": "some_details"}'
             assert trace_object['attributes']['message.data'] == processed_msg
-

--- a/tests/agent/mixins/agent_open_telemetry_test.py
+++ b/tests/agent/mixins/agent_open_telemetry_test.py
@@ -58,6 +58,48 @@ def testOpenTelemetryMixin_whenEmitMessage_shouldTraceMessage(agent_run_mock: ag
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='does not run on windows')
+def testOpenTelemetryMixin_whenEmitMessage_shouldNotTruncateOriginalMessage(
+            agent_run_mock: agent_testing.AgentRunInstance
+    ) -> None:
+    """Unit test for the OpenTelemetry Mixin, ensure the correct exporter has been used and trace span has been sent."""
+    breakpoint()
+    with tempfile.NamedTemporaryFile(suffix='.json') as tmp_file_obj:
+        agent_definition = agent_definitions.AgentDefinition(
+            name='some_name',
+            out_selectors=['v3.report.vulnerability'])
+        agent_settings = runtime_definitions.AgentSettings(
+            key='some_key',
+            tracing_collector_url=f'file://{tmp_file_obj.name}')
+        test_agent = TestAgent(
+            agent_definition=agent_definition,
+            agent_settings=agent_settings)
+
+        technical_detail = """Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. when an unknown printer took a galley of type and scrambled it to make a type specimen book."""
+        test_agent.emit('v3.report.vulnerability', {
+            'title': 'some_title',
+            'technical_detail': technical_detail,
+            'risk_rating': 'MEDIUM'
+        })
+        print('MSg : ', agent_run_mock.emitted_messages[0].data['technical_detail'])
+        test_agent.force_flush_file_exporter()
+
+        with open(tmp_file_obj.name, 'r', encoding='utf-8') as trace_file:
+            trace_content = trace_file.read()
+            trace_object = json.loads(trace_content)
+
+            assert trace_object['name'] == 'emit_message'
+            assert trace_object['attributes']['agent.name'] == 'some_name'
+            assert trace_object['attributes']['message.selector'] == 'v3.report.vulnerability'
+            # emitted_msg = '{"title": "some_title", "technical_detail": "some_details", "risk_rating": "MEDIUM"}'
+            # assert trace_object['attributes']['message.data'] == emitted_msg
+            # instrumented messages are supposed to send the message uuid, followed by trace id int and then span
+            # id int.
+
+            assert len(agent_run_mock.raw_messages[-1].key.split('-')) == 7
+        assert len(agent_run_mock.emitted_messages[0].data['technical_detail']) == len(technical_detail)
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='does not run on windows')
 def testOpenTelemetryMixin_whenProcessMessage_shouldTraceMessage(agent_mock: List[object]) -> None:
     """Unit test for the OpenTelemtry Mixin, ensure the correct exporter has been used and trace span has been sent."""
     del agent_mock
@@ -130,3 +172,4 @@ def testOpenTelemetryMixin_whenProcessMessageWithTraceIdSpanId_shouldInjectIdInC
             assert trace_object['attributes']['message.selector'] == 'v3.report.vulnerability'
             processed_msg = '{"title": "some_title", "risk_rating": "MEDIUM", "technical_detail": "some_details"}'
             assert trace_object['attributes']['message.data'] == processed_msg
+

--- a/tests/agent/mixins/agent_open_telemetry_test.py
+++ b/tests/agent/mixins/agent_open_telemetry_test.py
@@ -62,7 +62,6 @@ def testOpenTelemetryMixin_whenEmitMessage_shouldNotTruncateOriginalMessage(
             agent_run_mock: agent_testing.AgentRunInstance
     ) -> None:
     """Unit test for the OpenTelemetry Mixin, ensure the correct exporter has been used and trace span has been sent."""
-    breakpoint()
     with tempfile.NamedTemporaryFile(suffix='.json') as tmp_file_obj:
         agent_definition = agent_definitions.AgentDefinition(
             name='some_name',
@@ -74,27 +73,23 @@ def testOpenTelemetryMixin_whenEmitMessage_shouldNotTruncateOriginalMessage(
             agent_definition=agent_definition,
             agent_settings=agent_settings)
 
-        technical_detail = """Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. when an unknown printer took a galley of type and scrambled it to make a type specimen book."""
+        technical_detail = """Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum 
+        has been the standard dummy text ever since the 1500s, when an unknown printer took a galley of type and 
+        scrambled it to make a type specimen book. when an unknown printer took a galley of type and scrambled it to 
+        make a type specimen book. """
         test_agent.emit('v3.report.vulnerability', {
             'title': 'some_title',
             'technical_detail': technical_detail,
             'risk_rating': 'MEDIUM'
         })
-        print('MSg : ', agent_run_mock.emitted_messages[0].data['technical_detail'])
         test_agent.force_flush_file_exporter()
 
         with open(tmp_file_obj.name, 'r', encoding='utf-8') as trace_file:
             trace_content = trace_file.read()
             trace_object = json.loads(trace_content)
-
             assert trace_object['name'] == 'emit_message'
             assert trace_object['attributes']['agent.name'] == 'some_name'
             assert trace_object['attributes']['message.selector'] == 'v3.report.vulnerability'
-            # emitted_msg = '{"title": "some_title", "technical_detail": "some_details", "risk_rating": "MEDIUM"}'
-            # assert trace_object['attributes']['message.data'] == emitted_msg
-            # instrumented messages are supposed to send the message uuid, followed by trace id int and then span
-            # id int.
-
             assert len(agent_run_mock.raw_messages[-1].key.split('-')) == 7
         assert len(agent_run_mock.emitted_messages[0].data['technical_detail']) == len(technical_detail)
 


### PR DESCRIPTION
The minifier is not copying the original dict and is minifying the passed message as well.

The fix uses `deepcopy` to avoid altering the original message.