### PR TITLE
Remove deepcopy and emit message before minify_dict

### DIFF
--- a/src/ostorlab/agent/mixins/agent_open_telemetry_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_open_telemetry_mixin.py
@@ -13,7 +13,6 @@ import tempfile
 import uuid
 from typing import Any, Dict, Optional
 from urllib import parse
-import copy
 
 from opentelemetry import trace
 from opentelemetry.exporter import cloud_trace

--- a/src/ostorlab/agent/mixins/agent_open_telemetry_mixin.py
+++ b/src/ostorlab/agent/mixins/agent_open_telemetry_mixin.py
@@ -227,13 +227,11 @@ class OpenTelemetryMixin:
 
                 trace_id = emit_span.get_span_context().trace_id
                 span_id = emit_span.get_span_context().span_id
+                super().emit(selector, data, f'{message_id or uuid.uuid4()}-{trace_id}-{span_id}')
 
                 emit_span.set_attribute('agent.name', self.name)
                 emit_span.set_attribute('message.selector', selector)
-                cloned_data = copy.deepcopy(data)
-                minified_msg_data = dictionary_minifier.minify_dict(cloned_data, dictionary_minifier.truncate_str)
+                minified_msg_data = dictionary_minifier.minify_dict(data, dictionary_minifier.truncate_str)
                 emit_span.set_attribute('message.data', json.dumps(minified_msg_data))
-
-                super().emit(selector, data, f'{message_id or uuid.uuid4()}-{trace_id}-{span_id}')
         else:
             super().emit(selector, data)

--- a/tests/agent/mixins/agent_open_telemetry_test.py
+++ b/tests/agent/mixins/agent_open_telemetry_test.py
@@ -90,6 +90,7 @@ def testOpenTelemetryMixin_whenEmitMessage_shouldNotTruncateOriginalMessage(
             assert trace_object['name'] == 'emit_message'
             assert trace_object['attributes']['agent.name'] == 'some_name'
             assert trace_object['attributes']['message.selector'] == 'v3.report.vulnerability'
+            assert len(trace_object['attributes']['message.data']) < len(technical_detail)
             assert len(agent_run_mock.raw_messages[-1].key.split('-')) == 7
         assert len(agent_run_mock.emitted_messages[0].data['technical_detail']) == len(technical_detail)
 


### PR DESCRIPTION
Remove deepcopy since it slows the message processing and emits the message before minify_dict to avoid overriding the message content.