### PR TITLE
Add optional docker client to install agent api.

### DIFF
--- a/src/ostorlab/cli/install_agent.py
+++ b/src/ostorlab/cli/install_agent.py
@@ -112,19 +112,24 @@ def get_agent_details(agent_key: str) -> Dict:
         return agent_details
 
 
-def install(agent_key: str, version: str = "") -> None:
+def install(
+    agent_key: str,
+    version: str = "",
+    docker_client: Optional[docker.DockerClient] = None,
+) -> None:
     """Install an agent : Fetch the docker file location of the agent corresponding to the agent_key,
     and pull the image from the registry.
 
     Args:
         agent_key: key of the agent in agent/org/agentName format.
         version: version of the docker image.
+        docker_client: optional instance of the docker client to use to install the agent.
 
     Returns:
         None
 
     Raises:
-        click Exit exception with satus code 2 when the docker image does not exist.
+        click Exit exception with status code 2 when the docker image does not exist.
     """
 
     agent_details = get_agent_details(agent_key)
@@ -132,14 +137,14 @@ def install(agent_key: str, version: str = "") -> None:
     if agent_docker_location is None or not agent_details.get("versions", {}).get(
         "versions", []
     ):
-        console.error("Agent image location is not yet available")
+        console.error(f"Agent: {agent_key} image location is not yet available")
         raise click.exceptions.Exit(2)
 
     image_name = _image_name_from_key(agent_details["key"])
     logger.debug("searching for image name %s", image_name)
 
     try:
-        docker_client = docker.from_env()
+        docker_client = docker_client or docker.from_env()
 
         if _is_image_present(docker_client, image_name):
             console.info(f"{agent_key} already exist.")

--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -574,15 +574,18 @@ class LocalRuntime(runtime.Runtime):
                         return False
         return True
 
-    def install(self) -> None:
+    def install(self, docker_client: Optional[docker.DockerClient] = None) -> None:
         """Installs the default agents.
+
+        Args:
+            docker_client: optional instance of the docker client to use to install the agent.
 
         Returns:
             None
         """
         for agent_key in DEFAULT_AGENTS:
             try:
-                install_agent.install(agent_key=agent_key)
+                install_agent.install(agent_key=agent_key, docker_client=docker_client)
             except install_agent.AgentDetailsNotFound:
                 console.warning(f"agent {agent_key} not found on the store")
 

--- a/src/ostorlab/scanner/handler.py
+++ b/src/ostorlab/scanner/handler.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import ssl
 import sys
+import traceback
 from typing import Optional
 
 from nats.js import errors
@@ -102,6 +103,7 @@ class ClientBusHandler:
 
     async def _error_cb(self, e):
         logger.error("Error: %s", e)
+        logger.erro("Traceback: %s", traceback.print_exc())
 
     async def _closed_cb(self):
         logger.debug("Connection to Bus is closed.")


### PR DESCRIPTION
Useful to install agents using a logged-in docker client.
The client is logged-in programmatically, using the python `docker sdk`; client.login().