### PR TITLE
Handle same agent added multiple times in the agent group definition.

### DIFF
--- a/src/ostorlab/runtimes/lite_local/agent_runtime.py
+++ b/src/ostorlab/runtimes/lite_local/agent_runtime.py
@@ -349,7 +349,9 @@ class AgentRuntime:
             + "_"
             + self.runtime_name
             + "_"
-            + str(uuid.uuid4())[:7]
+            + str(uuid.uuid4())[
+                :7
+            ]  # We add only the first characters due the 64 characters limitations.
         )
 
         env = [

--- a/src/ostorlab/runtimes/lite_local/agent_runtime.py
+++ b/src/ostorlab/runtimes/lite_local/agent_runtime.py
@@ -350,7 +350,7 @@ class AgentRuntime:
             + "_"
             + self.runtime_name
             + "_"
-            + "".join([str(random.randint(1, 9)) for _ in range(5)])
+            + str(random.randrange(0, 9999))
         )
 
         env = [

--- a/src/ostorlab/runtimes/lite_local/agent_runtime.py
+++ b/src/ostorlab/runtimes/lite_local/agent_runtime.py
@@ -348,6 +348,8 @@ class AgentRuntime:
             or self.agent.container_image.replace(":", "_").replace(".", "")
             + "_"
             + self.runtime_name
+            + "_"
+            + str(uuid.uuid4())[:7]
         )
 
         env = [

--- a/src/ostorlab/runtimes/lite_local/agent_runtime.py
+++ b/src/ostorlab/runtimes/lite_local/agent_runtime.py
@@ -10,6 +10,7 @@ import io
 import logging
 import uuid
 import base64
+import random
 from typing import List, Optional
 
 import docker
@@ -349,9 +350,7 @@ class AgentRuntime:
             + "_"
             + self.runtime_name
             + "_"
-            + str(uuid.uuid4())[
-                :7
-            ]  # We add only the first characters due the 64 characters limitations.
+            + "".join([str(random.randint(1, 9)) for _ in range(5)])
         )
 
         env = [

--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -340,7 +340,9 @@ class AgentRuntime:
             + "_"
             + self.runtime_name
             + "_"
-            + str(uuid.uuid4())[:7]
+            + str(uuid.uuid4())[
+                :7
+            ]  # We add only the first characters due the 64 characters limitations.
         )
 
         env = [

--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -9,6 +9,7 @@ import logging
 import hashlib
 import uuid
 import base64
+import random
 from typing import List, Optional
 
 import docker
@@ -340,9 +341,7 @@ class AgentRuntime:
             + "_"
             + self.runtime_name
             + "_"
-            + str(uuid.uuid4())[
-                :7
-            ]  # We add only the first characters due the 64 characters limitations.
+            + "".join([str(random.randint(1, 9)) for _ in range(5)])
         )
 
         env = [

--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -339,6 +339,8 @@ class AgentRuntime:
             or self.agent.container_image.replace(":", "_").replace(".", "")
             + "_"
             + self.runtime_name
+            + "_"
+            + str(uuid.uuid4())[:7]
         )
 
         env = [

--- a/src/ostorlab/runtimes/local/agent_runtime.py
+++ b/src/ostorlab/runtimes/local/agent_runtime.py
@@ -341,7 +341,7 @@ class AgentRuntime:
             + "_"
             + self.runtime_name
             + "_"
-            + "".join([str(random.randint(1, 9)) for _ in range(5)])
+            + str(random.randrange(0, 9999))
         )
 
         env = [

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -216,18 +216,26 @@ def testScanInLocalRuntime_whenFlagToDisableDefaultAgentsIsPassed_shouldNotStart
     )
 
     start_agent_mock_call_args = agent_runtime_mock.call_args_list
-    assert start_agent_mock_call_args[0][0][0].key == "agent/ostorlab/agent42"
-    assert start_agent_mock_call_args[1][0][0].key == "agent/ostorlab/inject_asset"
+    start_agent_mock_call_args[0].agent_settings.key
+    assert (
+        start_agent_mock_call_args[0].kwargs["agent_settings"].key
+        == "agent/ostorlab/agent42"
+    )
+    assert (
+        start_agent_mock_call_args[1].kwargs["agent_settings"].key
+        == "agent/ostorlab/inject_asset"
+    )
     assert (
         all(
-            call_arg[0][0].key != "agent/ostorlab/local_persist_vulnz"
+            call_arg.kwargs["agent_settings"].key
+            != "agent/ostorlab/local_persist_vulnz"
             for call_arg in start_agent_mock_call_args
         )
         is True
     )
     assert (
         all(
-            call_arg[0][0].key != "agent/ostorlab/tracker"
+            call_arg.kwargs["agent_settings"].key != "agent/ostorlab/tracker"
             for call_arg in start_agent_mock_call_args
         )
         is True

--- a/tests/runtimes/local/runtime_test.py
+++ b/tests/runtimes/local/runtime_test.py
@@ -216,7 +216,6 @@ def testScanInLocalRuntime_whenFlagToDisableDefaultAgentsIsPassed_shouldNotStart
     )
 
     start_agent_mock_call_args = agent_runtime_mock.call_args_list
-    start_agent_mock_call_args[0].agent_settings.key
     assert (
         start_agent_mock_call_args[0].kwargs["agent_settings"].key
         == "agent/ostorlab/agent42"


### PR DESCRIPTION
We add part of the uuid to avoid conflict when having the same agent added multiple times in the agent group definition