### PR TITLE
Revert the change of the behavior to fail if an argument is present in the settings but not in the agent definition

### DIFF
--- a/src/ostorlab/agent/agent.py
+++ b/src/ostorlab/agent/agent.py
@@ -46,10 +46,6 @@ class MaximumCyclicProcessReachedError(exceptions.OstorlabError):
     """The cyclic process limit is enforced and reach set value."""
 
 
-class ArgumentMissingInAgentDefinitionError(exceptions.OstorlabError):
-    """Argument is present in the settings but not in the agent definition."""
-
-
 def _setup_logging(agent_key: str, universe: str) -> None:
     gcp_logging_credential = os.environ.get(GCP_LOGGING_CREDENTIAL_ENV)
     if gcp_logging_credential is not None:
@@ -133,12 +129,12 @@ class AgentMixin(
         for a in self.settings.args:
             # Enforce that only declared arguments are accepted.
             if a.name not in arguments:
+                # TODO(OS-5119): Change behavior to fail of the argument is missing from definition.
                 logger.warning(
                     "Argument %s is defined in the agent settings but not in the agent definition. "
                     "Please update your definition file or the agent will fail in the future.",
                     a.name,
                 )
-                raise ArgumentMissingInAgentDefinitionError()
 
             if a.type == "binary":
                 arguments[a.name] = a.value

--- a/tests/agent/agent_test.py
+++ b/tests/agent/agent_test.py
@@ -159,37 +159,38 @@ def testAgent_withDefaultAndSettingsArgs_returnsExpectedArgs(agent_mock):
     assert test_agent.args == {"color": "red", "speed": b"slow"}
 
 
+@pytest.mark.xfail(reason="OS-5119: Awaiting deprecation.")
 def testAgent_withArgMissingFromDefinition_raisesException(agent_mock):
     class TestAgent(agent.Agent):
         """Test Agent"""
 
-    with pytest.raises(agent.ArgumentMissingInAgentDefinitionError):
-        test_agent = TestAgent(
-            agent_definitions.AgentDefinition(
-                name="start_test_agent",
-                out_selectors=["v3.healthcheck.ping"],
-                args=[
-                    {"name": "color", "type": "string", "value": None},
-                    {"name": "speed", "type": "string", "value": b"fast"},
-                ],
-            ),
-            runtime_definitions.AgentSettings(
-                key="agent/ostorlab/start_test_agent",
-                bus_url="amqp://guest:guest@localhost:5672/",
-                bus_exchange_topic="ostorlab_test",
-                healthcheck_port=5301,
-                args=[
-                    utils_definitions.Arg(name="speed", type="binary", value=b"slow"),
-                    utils_definitions.Arg(
-                        name="color", type="string", value=json.dumps("red").encode()
-                    ),
-                    utils_definitions.Arg(
-                        name="force", type="string", value=json.dumps("strong").encode()
-                    ),
-                ],
-            ),
-        )
-        assert test_agent.args is None
+    test_agent = TestAgent(
+        agent_definitions.AgentDefinition(
+            name="start_test_agent",
+            out_selectors=["v3.healthcheck.ping"],
+            args=[
+                {"name": "color", "type": "string", "value": None},
+                {"name": "speed", "type": "string", "value": b"fast"},
+            ],
+        ),
+        runtime_definitions.AgentSettings(
+            key="agent/ostorlab/start_test_agent",
+            bus_url="amqp://guest:guest@localhost:5672/",
+            bus_exchange_topic="ostorlab_test",
+            healthcheck_port=5301,
+            args=[
+                utils_definitions.Arg(name="speed", type="binary", value=b"slow"),
+                utils_definitions.Arg(
+                    name="color", type="string", value=json.dumps("red").encode()
+                ),
+                utils_definitions.Arg(
+                    name="force", type="string", value=json.dumps("strong").encode()
+                ),
+            ],
+        ),
+    )
+
+    assert test_agent.args == {"color": "red", "speed": b"slow"}
 
 
 def testEmit_whenEmitFromNoProcess_willSendTheAgentNameInControlAgents(


### PR DESCRIPTION
Reverts Ostorlab/ostorlab#516