### PR TITLE
Add minimum python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-# python_requires = >=3.8
+python_requires = >=3.9
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in


### PR DESCRIPTION
I realized that my PR against the KEV
repo (https://github.com/Ostorlab/KEV/pull/68)
was somewhat misguided. The correct
place to fix this issue is in the metadata
about the package.