### PR TITLE
Remove pre-agents healthcheck since it is included in the agents healthcheck

### DIFF
--- a/src/ostorlab/runtimes/local/runtime.py
+++ b/src/ostorlab/runtimes/local/runtime.py
@@ -202,10 +202,6 @@ class LocalRuntime(runtime.Runtime):
             if self._run_default_agents is True:
                 console.info("Starting pre-agents")
                 self._start_pre_agents()
-                console.info("Checking pre-agents are healthy")
-                is_healthy = self._check_agents_healthy()
-                if is_healthy is False:
-                    raise AgentNotHealthy()
 
             console.info("Starting agents")
             self._start_agents(agent_group_definition)


### PR DESCRIPTION
Remove pre-agents health check since it is included in the agents health check done just after.
With this configuration, we optimize the sequence:

Start pre-agent
Wait to become healthy 
Start agents
wait max(agent) to become healthy 

To

Start pre-agent
Start agents
wait max(agent + pre-agent) to become healthy 
