### PR TITLE
Check core services after starting all of them.

### DIFF
--- a/src/ostorlab/runtimes/local/services/jaeger.py
+++ b/src/ostorlab/runtimes/local/services/jaeger.py
@@ -72,12 +72,6 @@ class LocalJaeger:
         self._create_network()
         self._jaeger_service = self._start_jaeger()
 
-        if self._jaeger_service is not None and not self._is_service_healthy():
-            logger.error(
-                "Jaeger container for service %s is not ready", self._jaeger_service.id
-            )
-            return
-
     def stop(self):
         """Stop the local Jaeger instance."""
         for service in self._docker_client.services.list():
@@ -128,12 +122,12 @@ class LocalJaeger:
 
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(20),
-        wait=tenacity.wait_exponential(multiplier=1, max=12),
+        wait=tenacity.wait_fixed(0.5),
         # return last value and don't raise RetryError exception.
         retry_error_callback=lambda lv: lv.outcome,
         retry=tenacity.retry_if_result(lambda v: v is False),
     )
-    def _is_service_healthy(self) -> bool:
+    def is_service_healthy(self) -> bool:
         logger.info("checking service %s", self._jaeger_service.name)
         return self.is_healthy
 

--- a/src/ostorlab/runtimes/local/services/mq.py
+++ b/src/ostorlab/runtimes/local/services/mq.py
@@ -74,12 +74,6 @@ class LocalRabbitMQ:
         self._create_network()
         self._mq_service = self._start_mq()
 
-        if self._mq_service is not None and not self._is_service_healthy():
-            logger.error(
-                "MQ container for service %s is not ready", self._mq_service.id
-            )
-            return
-
     def stop(self):
         """Stop local Rabiit MQ instance."""
         for service in self._docker_client.services.list():
@@ -171,12 +165,12 @@ class LocalRabbitMQ:
 
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(20),
-        wait=tenacity.wait_exponential(multiplier=1, max=12),
+        wait=tenacity.wait_fixed(0.5),
         # return last value and don't raise RetryError exception.
         retry_error_callback=lambda lv: lv.outcome,
         retry=tenacity.retry_if_result(lambda v: v is False),
     )
-    def _is_service_healthy(self) -> bool:
+    def is_service_healthy(self) -> bool:
         logger.info("checking service %s", self._mq_service.name)
         return self.is_healthy
 

--- a/src/ostorlab/runtimes/local/services/redis.py
+++ b/src/ostorlab/runtimes/local/services/redis.py
@@ -56,12 +56,6 @@ class LocalRedis:
         self._create_network()
         self._redis_service = self._start_redis()
 
-        if self._redis_service is not None and not self._is_service_healthy():
-            logger.error(
-                "Redis container for service %s is not ready", self._redis_service.id
-            )
-            return
-
     def stop(self):
         """Stop the local Redis instance."""
         for service in self._docker_client.services.list():
@@ -112,12 +106,12 @@ class LocalRedis:
 
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(20),
-        wait=tenacity.wait_exponential(multiplier=1, max=12),
+        wait=tenacity.wait_fixed(0.5),
         # return last value and don't raise RetryError exception.
         retry_error_callback=lambda lv: lv.outcome,
         retry=tenacity.retry_if_result(lambda v: v is False),
     )
-    def _is_service_healthy(self) -> bool:
+    def is_service_healthy(self) -> bool:
         logger.info("checking service %s", self._redis_service.name)
         return self.is_healthy
 


### PR DESCRIPTION
Check core services after starting all of them.

Current pattern:

Start MQ
Wait X seconds MQ becomes healthy
Start Redis
Wait Y seconds Redis becomes healthy
Start Jaeger
Wait Z seconds Jaeger becomes healthy 

Optimization:

Start MQ
Start Redis
Start Jaeger
Wait max(X+Y+Z ) seconds all services to become healthy 
